### PR TITLE
Add support for JCB and Diners Club cards.

### DIFF
--- a/src/balanced.js
+++ b/src/balanced.js
@@ -183,6 +183,7 @@ function noDataError(callback, message) {
 }
 
 var cc = {
+  
     isCardNumberValid:function (cardNumber) {
         if (!cardNumber) {
             return false;
@@ -204,6 +205,8 @@ var cc = {
         p['34'] = p['37'] = 'American Express';
         p['4'] = 'VISA';
         p['6'] = 'Discover Card';
+        p['35'] = 'JCB';
+        p['30'] = p['36'] = p['38'] = 'Diners Club';
 
         if (cardNumber) {
             cardNumber = cardNumber.toString().trim();

--- a/test/unit/cards.js
+++ b/test/unit/cards.js
@@ -159,6 +159,14 @@ test('cardType', function (assert) {
             expected: 'VISA'
         },
         {
+            number: '30569309025904',
+            expected: 'Diners Club'
+        },
+        {
+            number: '3530111333300000',
+            expected: 'JCB'
+        },
+        {
             number: 'no numbers in hurr',
             expected: null
         },
@@ -245,6 +253,26 @@ test('isSecurityCodeValid', function (assert) {
         {
             number: '378734493671000',
             csc: null,
+            expected: false
+        },
+        {
+            number: '3530111333300000',
+            csc: '123',
+            expected: true
+        },
+        {
+            number: '3530111333300000',
+            csc: '12',
+            expected: false
+        },
+        {
+            number: '30569309025904',
+            csc: '123',
+            expected: true
+        },
+        {
+            number: '30569309025904',
+            csc: '12',
             expected: false
         },
         {
@@ -467,6 +495,20 @@ test('validate', function (assert) {
             expiration_year: '2030',
             cvv: 1234,
             expected_length: 1
+        },
+        {
+            number: '3530111333300000',
+            expiration_month: '1',
+            expiration_year: '2030',
+            cvv: '123',
+            expected_length: 0
+        },
+        {
+            number: '30569309025904',
+            expiration_month: '1',
+            expiration_year: '2030',
+            cvv: '123',
+            expected_length: 0
         }
     ];
 
@@ -477,13 +519,13 @@ test('validate', function (assert) {
 });
 
 
-asyncTest('create', 4, function(assert) {
+asyncTest('create', 6, function(assert) {
     var count = 0;
 
     function callback(response) {
         assert.equal(response.status_code, 201);
 
-        if(++count == 4) {
+        if(++count == 6) {
             start();
         }
 
@@ -512,8 +554,19 @@ asyncTest('create', 4, function(assert) {
             number: '378734493671000',
             expiration_month: '1',
             expiration_year: 2030
+        },
+        {
+            number: '3530111333300000',
+            expiration_month: '1',
+            expiration_year: '2030',
+            cvv: 123
+        },
+        {
+            number: '30569309025904',
+            expiration_month: '1',
+            expiration_year: '2030',
+            cvv: '123'
         }
-
     ];
 
     for(var i = 0; i < tests.length; i++) {


### PR DESCRIPTION
According to the [documentation](https://support.balancedpayments.com/hc/en-us/articles/200319895-Does-Balanced-accept-JCB-and-Diners-Club-cards) Balanced supports JCB and Diners, but they weren't recognized by balanced-js. I added support for their prefixes based on Wikipedia. Also added test card numbers found elsewhere online; these should be changed if there are specific numbers you support.

-Zach
