### PR TITLE
Renamed parameter type to account_type when creating bank account

### DIFF
--- a/src/balanced.js
+++ b/src/balanced.js
@@ -308,8 +308,9 @@ var ba = {
             errors.push(buildErrorObject(noun, 'Invalid field [' + noun + '] - "' + bankCode + '" is not a valid ' + noun.replace('_', ' ')));
         }
         var account_type = accountData.type || accountData.account_type;
-        if (('type' in accountData || 'account_type' in accountData) && !ba.validateType(account_type)) {
-            errors.push(buildErrorObject('type', 'Invalid field [type] - "' + account_type + '" must be one of: "' + ba.types.join('", "') + '"'));
+        var type_name = 'type' in accountData ? 'type' : 'account_type';
+        if (accountData[type_name] && !ba.validateType(account_type)) {
+            errors.push(buildErrorObject(type_name, 'Invalid field [' + type_name + '] - "' + account_type + '" must be one of: "' + ba.types.join('", "') + '"'));
         }
         return errors;
     },

--- a/src/balanced.js
+++ b/src/balanced.js
@@ -183,7 +183,7 @@ function noDataError(callback, message) {
 }
 
 var cc = {
-  
+
     isCardNumberValid:function (cardNumber) {
         if (!cardNumber) {
             return false;
@@ -307,8 +307,9 @@ var ba = {
         if (!ba.validateRoutingNumber(bankCode)) {
             errors.push(buildErrorObject(noun, 'Invalid field [' + noun + '] - "' + bankCode + '" is not a valid ' + noun.replace('_', ' ')));
         }
-        if ('type' in accountData && !ba.validateType(accountData.type)) {
-            errors.push(buildErrorObject('type', 'Invalid field [type] - "' + accountData.type + '" must be one of: "' + ba.types.join('", "') + '"'));
+        var account_type = accountData.type || accountData.account_type;
+        if (('type' in accountData || 'account_type' in accountData) && !ba.validateType(account_type)) {
+            errors.push(buildErrorObject('type', 'Invalid field [type] - "' + account_type + '" must be one of: "' + ba.types.join('", "') + '"'));
         }
         return errors;
     },
@@ -366,6 +367,9 @@ var ba = {
                 errors: errors
             });
         } else {
+            if ('type' in data && !'account_type' in data) {
+                data.account_type = data.type;
+            }
             jsonp(make_url('/jsonp/bank_accounts', preparePayload(data)), make_callback(callback));
         }
     }

--- a/test/unit/bank_accounts.js
+++ b/test/unit/bank_accounts.js
@@ -70,38 +70,66 @@ test('validate', function (assert) {
         },
         {
             bank_code: '1210003742',
-            expected_length: 1
+            expected_length: 1,
+            expected_keys: ['bank_code']
         },
         {
             routing_number: '',
-            expected_length: 1
+            expected_length: 1,
+            expected_keys: ['routing_number']
         },
         {
             routing_number: null,
-            expected_length: 1
+            expected_length: 1,
+            expected_keys: ['routing_number']
         },
         {
             routing_number: 'no numbers in hurr',
-            expected_length: 1
+            expected_length: 1,
+            expected_keys: ['routing_number']
         },
         {
             bank_code: ' 121-000374-2 ',
-            expected_length: 1
+            expected_length: 1,
+            expected_keys: ['bank_code']
         },
         {
             routing_number: '121000374',
             type: 'foo',
-            expected_length: 1
+            expected_length: 1,
+            expected_keys: ['type']
+        },
+        {
+            routing_number: '121000374',
+            account_type: 'foo',
+            expected_length: 1,
+            expected_keys: ['account_type']
         },
         {
             routing_number: 'no numbers in hurr',
             type: 'foo',
-            expected_length: 2
+            expected_length: 2,
+            expected_keys: ['type', 'routing_number']
+        },
+        {
+            routing_number: 'no numbers in hurr',
+            account_type: 'foo',
+            expected_length: 2,
+            expected_keys: ['account_type', 'routing_number']
         }
     ];
 
     for(var i = 0; i < tests.length; i++) {
-        assert.equal(Object.keys(balanced.bankAccount.validate(tests[i])).length, tests[i].expected_length, "Test #" + (i + 1));
+        var validationErrors = balanced.bankAccount.validate(tests[i]);
+        assert.equal(Object.keys(validationErrors).length, tests[i].expected_length, "Test #" + (i + 1) + " key count incorrect");
+
+        for (var j = 0; j < validationErrors.length; j++) {
+            var obj = validationErrors[j];
+
+            for (key in obj.extras) {
+                assert.ok(tests[i].expected_keys.indexOf(key) >= 0, "Test #" + (i + 1) + " keys incorrect");
+            }
+        }
     }
 });
 


### PR DESCRIPTION
Fixes #72

This will work with both `type` and `account_type` parameters being passed in. It will just rewrite `type` to `account_type`
